### PR TITLE
Update linter to work with SublimeLinter 4, remove unneeded overrides of superclass

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -10,31 +10,18 @@
 
 """This module exports the Swiftlint plugin class."""
 
-from SublimeLinter.lint import Linter, util
+from SublimeLinter.lint import Linter
 
 
 class Swiftlint(Linter):
     """Provides an interface to swiftlint."""
 
-    syntax = 'swift'
     cmd = ('swiftlint', 'lint', '--use-stdin')
-    executable = None
-    version_args = 'version'
-    version_re = r'(?P<version>\d+\.\d+\.\d+)'
-    version_requirement = '>= 0.9.1'
     regex = (
         r'^.+?:(?P<line>\d+):(?P<col>\d+)?:? '
         r'(?:(?P<error>error)|(?P<warning>warning)): '
         r'(?P<message>.+)'
     )
-    multiline = False
-    line_col_base = (1, 1)
-    tempfile_suffix = None
-    config_file = ('--config', '.swiftlint.yml')
-    error_stream = util.STREAM_BOTH
-    selectors = {}
-    word_re = None
-    defaults = {}
-    inline_settings = None
-    inline_overrides = None
-    comment_re = None
+    defaults = {
+        'selector': 'source.swift'
+    }


### PR DESCRIPTION
Fixes #5 plus a few other changes. 

* `util` import is unused, caught by flake8
* `syntax`, `executable`, `version_args`,  `version_re`, `version_requirement`, `config_file`, `inline_settings`, `inline_overrides`, `comment_re`, `selectors`  no longer have any effect
* SublimeLinter template's [HOWTO.md](https://github.com/SublimeLinter/SublimeLinter-template/blob/master/HOWTO.md) says you should remove unchanged attributes (I agree, it makes it confusing what's an override and what isn't) so I've removed `multiline`, `line_col_base`, `tempfile_suffix`, `error_stream`
* it's now required that `defaults` contains a `selector`, so added that (this is what broke the plugin in the first place, see SublimeLinter/SublimeLinter#1578)
* I also took out the `word_re` override to `None`, as it means only the first character of the relevant word gets highlighted, and I find it easier to spot the violation when the whole word gets selected.

Anyway, feel free to accept or reject as much of this as you'd like, and thanks again for this package, has been super useful to me for a while now!